### PR TITLE
Update UDTW23 Document with Final Version Note

### DIFF
--- a/translated-sentences/otk-orkh-202311.adoc
+++ b/translated-sentences/otk-orkh-202311.adoc
@@ -1,5 +1,7 @@
-= UDTW23 Translated Sentences for Old Turkish language (otk) and Old Turkic script (orkh)
+= Partial Document 202311 of UDTW23 Translated Sentences for Old Turkish language (otk) and Old Turkic script (orkh)
 :toc:
+
+NOTE: This document, titled "UDTW23 Translated Sentences for Old Turkish language (otk) and Old Turkic script (orkh)," is designated with version "202311" to be partial and will no longer receive updates. Any future work or modifications related to the subject matter of this document, particularly authoring for the language and script pair of Old Turkish and Old Turkic, should be pursued by creating a separate document. This approach ensures the content remains consistent and historically accurate as of its last update.
 
 == Conventions
 


### PR DESCRIPTION
Due to time constraints and priorities, I'll no longer be able to contribute data either in translation or annotation form within this workshop follow-up, contribute to infra where I can, and rather focus and concentrate my efforts on orchestrating the reworked upbringing of my dataset within UD. This commit marks the UDTW23 document for Old Turkish language (otk) and Old Turkic script (orkh) as its final version. A note has been added to indicate that the document, versioned "202311," will no longer receive updates. Future work on this subject is advised to be handled in a separate document.

Key changes:
- Added a NOTE section to clarify that the document is frozen and will not be updated.
- Specified the version as "202311" for historical and reference purposes.
- Advised the creation of a new document for any further authoring related to the language and script pair.